### PR TITLE
boost scores if query matches item exactly

### DIFF
--- a/src/FuzzySearch.js
+++ b/src/FuzzySearch.js
@@ -95,6 +95,12 @@ module.exports = class FuzzySearch {
       }
     }
 
+    if (item === query) {
+      score /= 10;
+    } else if (item.startsWith(query)) {
+      score /= 2;
+    }
+
     return score;
   }
 };


### PR DESCRIPTION
Scores should be boosted if the query matches the item exactly.

example:

```javascript
const FuzzySearch = require('./dist/FuzzySearch');

const searcher = new FuzzySearch(
  [{ name: 'r' }, { name: 'rust' }, { name: 'ruby' }, { name: 'prolog' }], ['name'],
  { sort: true } );

console.log(searcher.search('r')); // the first item must be 'r' and the last item must be 'prolog'
```