### PR TITLE
package.module = 'src/FuzzySearch.js'

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.1.0",
   "description": "Simple fuzzy search",
   "main": "./dist/FuzzySearch.js",
+  "module": "src/FuzzySearch.js",
   "devDependencies": {
     "@babel/register": "^7.6.2",
     "cross-env": "^6.0.3",


### PR DESCRIPTION
This would allow various build tools to import the ESM module directly.

In my case, I'm using [rollup.js](https://rollupjs.org/), and without this change, I have to also use `rollup-plugin-commonjs` to convert the CommonJS version to an artificial ESM module.